### PR TITLE
**1.2.1**

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Action functionality:
     - Fix regexp for the old version in the `readme-changelog` version
     - Fix `change-only-for` array-split
     - Change Git current branch retrieval to support Git version < 2.22 
+    - Fix label for the `readme-action` label
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # check-version-sh
 
-[![Marketplace](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/marketplace/actions/check-version-sh)
+[![Marketplace](https://img.shields.io/badge/version-1.2.1-blue)](https://github.com/marketplace/actions/check-version-sh)
 
 Action functionality:
 
@@ -32,6 +32,10 @@ Action functionality:
     - Add `package-lock.json` file support
     - Add `readme-action` label support
     - Fix digit regexp for the `readme-badge` label
+- **1.2.1**
+    - Fix regexp for the old version in the `readme-changelog` version
+    - Fix `change-only-for` array-split
+    - Change Git current branch retrieval to support Git version < 2.22 
 
 ## Usage
 
@@ -68,7 +72,7 @@ jobs:
   steps:
     # ...
     - name: Check Version Changes
-      uses: sivkovych/check-version-sh@v1.2.0
+      uses: sivkovych/check-version-sh@v1.2.1
       with:
         log-level: "INFO"
         check-only-for: "pom.xml,package.json,readme-badge"

--- a/src/action.sh
+++ b/src/action.sh
@@ -28,8 +28,8 @@ while [ ${#} -gt 0 ]; do
         info::get_usage
         exit 0
     elif [[ "${1}" == "--check-only-for" ]]; then
-        # shellcheck disable=SC2206
-        check_only_for=(${2/,/ })
+        # shellcheck disable=SC2207
+        check_only_for=($(echo "${2}" | tr "," " "))
         shift
     elif [[ "${1}" == "--"* ]]; then
         variable="${1/--/}"

--- a/src/check-version/git.sh
+++ b/src/check-version/git.sh
@@ -1,7 +1,7 @@
 #section Public API
 git::branch() {(
     set -e
-    git branch --show-current
+    git rev-parse --abbrev-ref HEAD
 )}
 git::fetch() {(
     set -e

--- a/src/check-version/version-in/readme-action.sh
+++ b/src/check-version/version-in/readme-action.sh
@@ -1,6 +1,6 @@
 #section Public API
 version::label() {
-    echo "readme-badge"
+    echo "readme-action"
 }
 version::file_name() {
     echo "README.md"

--- a/src/check-version/version-in/readme-changelog.sh
+++ b/src/check-version/version-in/readme-changelog.sh
@@ -8,7 +8,8 @@ version::file_name() {
 version::old() {
     echo "${1}" |
         local::grep -v "+" |
-        local::grep -Po "(?<=-\*\*)(([0-9]{1,}|[.-/#])+?)(?=\*\*)"
+        local::grep -Po "(?<=-\*\*)(([0-9]{1,}|[.-/#])+?)(?=\*\*)" |
+        tail -1
 }
 version::new() {
     echo "${1}" |


### PR DESCRIPTION
    - Fix regexp for the old version in the `readme-changelog` version
    - Fix `change-only-for` array-split
    - Change Git current branch retrieval to support Git version < 2.22